### PR TITLE
Refine splash info bar: LinkedIn icon-only + CSS separators + mobile polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,10 +36,8 @@
 
     <div class="info">
       <a class="info-item" href="mailto:hello@solidpd.com">hello@solidpd.com</a>
-      <span class="separator" aria-hidden="true">•</span>
       <a class="info-item" href="https://maps.google.com/?q=2212%20Walnut%20Street,%201st%20Floor,%20Philadelphia,%20PA%2019103" target="_blank" rel="noopener">2212 Walnut Street, 1st Floor, Philadelphia, PA 19103</a>
-      <span class="separator" aria-hidden="true">•</span>
-      <a class="info-item" href="https://www.linkedin.com/company/solidpd/" target="_blank" rel="noopener"><svg class="icon" aria-hidden="true" viewBox="0 0 24 24" focusable="false"><path fill="currentColor" d="M20.447 20.452h-3.554v-5.569c0-1.328-.026-3.039-1.852-3.039-1.853 0-2.136 1.447-2.136 2.943v5.665H9.35V9h3.414v1.561h.049c.476-.9 1.637-1.852 3.369-1.852 3.602 0 4.268 2.371 4.268 5.455v6.288zM5.337 7.433a2.062 2.062 0 1 1 0-4.124 2.062 2.062 0 0 1 0 4.124zM6.997 20.452H3.675V9h3.322v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>LinkedIn</a>
+      <a class="info-item icon-only" href="https://www.linkedin.com/company/solidpd/" target="_blank" rel="noopener" aria-label="Solid Product Design on LinkedIn"><svg class="icon" aria-hidden="true" viewBox="0 0 24 24" focusable="false"><path fill="currentColor" d="M20.447 20.452h-3.554v-5.569c0-1.328-.026-3.039-1.852-3.039-1.853 0-2.136 1.447-2.136 2.943v5.665H9.35V9h3.414v1.561h.049c.476-.9 1.637-1.852 3.369-1.852 3.602 0 4.268 2.371 4.268 5.455v6.288zM5.337 7.433a2.062 2.062 0 1 1 0-4.124 2.062 2.062 0 0 1 0 4.124zM6.997 20.452H3.675V9h3.322v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg></a>
     </div>
   </main>
 </body>

--- a/style.css
+++ b/style.css
@@ -9,13 +9,32 @@ body{margin:0;font-family:"DM Sans",system-ui,-apple-system,Segoe UI,Roboto,Helv
 .btn{display:inline-block;padding:12px 18px;border-radius:999px;text-decoration:none;font-weight:700;letter-spacing:.2px;transition:transform .15s ease}
 .btn.primary{background:var(--text);color:#0a4f7a}
 .btn.primary:hover{transform:translateY(-1px)}
-.info{display:flex;gap:14px;justify-content:center;flex-wrap:wrap;margin-top:6px;font-size:15px}
+.info{display:flex;gap:0;justify-content:center;flex-wrap:wrap;margin-top:6px;font-size:15px}
 .info-item{color:var(--muted);text-decoration:none}
 .info-item:hover{color:var(--text)}
 .separator{opacity:.6;color:var(--muted)}
+/* CSS-only separators */
+.info-item{position:relative;padding:0 10px;display:inline-flex;align-items:center}
+.info-item + .info-item{margin-left:10px}
+.info-item + .info-item:before{content:"\2022";position:relative;left:-10px;color:var(--muted);opacity:.6}
+/* Remove extra padding on first and last items */
+.info .info-item:first-child{padding-left:0}
+.info .info-item:last-child{padding-right:0}
+
+/* Icon-only LinkedIn */
+.info-item.icon-only{padding-left:10px;padding-right:0}
+.info-item.icon-only .icon{width:16px;height:16px;margin:0}
+
+/* Mobile: stack items nicely and hide separators */
+@media (max-width:640px){
+  .info{gap:8px}
+  .info-item{padding:0}
+  .info-item + .info-item{margin-left:0}
+  .info-item + .info-item:before{content:none}
+}
+
 
 /* Icon styling inside info links */
-.info-item{display:inline-flex;align-items:center}
 .info-item .icon{width:16px;height:16px;margin-right:6px;flex:0 0 auto}
 
 /* Improve mobile layout by removing dot separators on small screens */


### PR DESCRIPTION
Summary
- Add inline SVG LinkedIn icon as an icon-only link at the end of the info row
- Replace hardcoded bullet separators with CSS-generated separators
- Improve mobile behavior: hide separators when stacked, maintain clean spacing

Details
- index.html
  - Converted LinkedIn text link to icon-only link with accessible aria-label
  - Removed inline bullet separators from markup for cleaner HTML
- style.css
  - Implemented CSS-only separators via `.info-item + .info-item:before` using a middot
  - Adjusted `.info-item` to inline-flex and added spacing that looks crisp on desktop
  - On mobile (≤640px): separators are removed and spacing simplified for clean stacking

Rationale
- Keeps markup minimal and semantic while offering consistent layout control in CSS
- Ensures the LinkedIn icon is small, elegant, and last in order on all viewports
- Eliminates awkward line-break bullets on mobile

Testing
- Verified visually at common breakpoints (mobile, tablet, desktop)
- Checked hover states and color inheritance via `currentColor`

Accessibility
- Icon-only link includes `aria-label` for screen readers

Notes
- Breakpoint currently 640px; happy to adjust per design preferences

Co-authored-by: openhands <openhands@all-hands.dev>

@bradflaugher can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7255b57e9ecf40748e9a31ee09310483)