### PR TITLE
Update address format to display street/floor and city/state/zip on separate lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,9 +173,17 @@
       width: 100%;
     }
 
-    /* Address styling - single line on desktop */
+    /* Address styling - two lines */
     .contact-item.address {
       text-align: center;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .address-line1,
+    .address-line2 {
+      display: block;
+      line-height: 1.3;
     }
 
 
@@ -353,7 +361,8 @@
     <div class="contact-section">
       <div class="contact-row">
         <a class="contact-item address" href="https://maps.google.com/?q=2212%20Walnut%20Street,%201st%20Floor,%20Philadelphia,%20PA%2019103" target="_blank" rel="noopener">
-          <span>2212 Walnut Street, 1st Floor, Philadelphia, PA 19103</span>
+          <span class="address-line1">2212 Walnut Street, 1st Floor</span>
+          <span class="address-line2">Philadelphia, PA 19103</span>
         </a>
         
         <a class="contact-item" href="mailto:hello@solidpd.com">


### PR DESCRIPTION
## Summary
This PR updates the address display format on the website to improve readability by splitting the address into two separate lines.

## Changes Made
- **HTML Structure**: Modified the address link to use two separate `<span>` elements for better semantic structure
- **CSS Styling**: Added new styles to properly format the two-line address display
- **Responsive Design**: Maintained existing responsive behavior across all device sizes

## Before
```
2212 Walnut Street, 1st Floor, Philadelphia, PA 19103
```

## After
```
2212 Walnut Street, 1st Floor
Philadelphia, PA 19103
```

## Technical Details
- Line 1: Street address and floor number
- Line 2: City, state, and zip code
- Uses `flex-direction: column` with appropriate gap spacing
- Maintains clickable functionality for Google Maps integration
- Preserves existing visual consistency and hover effects

## Testing
- ✅ Verified display on desktop view
- ✅ Confirmed responsive behavior is maintained
- ✅ Address link functionality preserved
- ✅ Visual consistency with existing design maintained

@mattbell-spd can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ccc0a916d490479584424328ff2c896d)