### PR TITLE
Fix contact section bullet spacing for equal spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
       align-items: center;
       justify-content: center;
       gap: 6px;
-      padding: 8px 20px;
+      padding: 8px 16px;
       position: relative;
       white-space: nowrap;
     }
@@ -157,7 +157,7 @@
     .contact-item:not(:last-child)::after {
       content: '•';
       position: absolute;
-      right: -12px;
+      right: -16px;
       color: rgba(255, 255, 255, 0.5);
       font-size: 12px;
       pointer-events: none;


### PR DESCRIPTION
## Summary
Fixed the bullet spacing in the contact section to ensure equal spacing on both sides of each bullet separator.

## Changes Made
- **Adjusted contact item padding**: Changed from `padding: 8px 20px` to `padding: 8px 16px` for more balanced horizontal spacing
- **Updated bullet position**: Changed from `right: -12px` to `right: -16px` to center bullets perfectly between contact items

## Result
The contact section now displays with consistent spacing:
`[address] - space - bullet - space - [email] - space - bullet - space - [linkedin icon]`

Where all spaces are equal in width, creating a clean and balanced visual appearance.

## Testing
- ✅ Verified spacing looks correct on desktop view
- ✅ Confirmed mobile responsive design is preserved (bullets hidden, items stack vertically)
- ✅ All contact links remain functional

## Visual Impact
This change improves the visual balance and professional appearance of the contact section without affecting functionality or responsive behavior.

@mattbell-spd can click here to [continue refining the PR](https://app.all-hands.dev/conversations/77924fffefa147ea91d3c3fb6cf2beb6)