### PR TITLE
feat: Trigger deployment on push to any branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,7 @@ name: Deploy Static Site to Netlify
 on:
   push:
     branches:
-      - main
-      - dev
+      - '**'
 
 jobs:
   deploy:
@@ -33,4 +32,3 @@ jobs:
           else
             netlify deploy --dir=temp_deploy
           fi
-


### PR DESCRIPTION
This change updates the GitHub Actions workflow to trigger a deployment on a push to any branch, not just `main` and `dev`.

The deployment logic remains the same, with production deployments only occurring on pushes to the `main` branch.