### PR TITLE
Refactor: Clean up footer and update job title

### DIFF
--- a/src/about.html
+++ b/src/about.html
@@ -86,7 +86,7 @@
                         <img src="./assets/images/MS.jpg" alt="Matt Starfield" />
                     </div>
                     <h3>Matt Starfield</h3>
-                    <p><strong>Senior Electrical Engineer</strong> • MS Electrical Engineering, Drexel University</p>
+                    <p><strong>Electrical Engineer</strong> • MS Electrical Engineering, Drexel University</p>
                     <div class="highlights">
                         <ul>
                             <li><strong>CID+ Certified</strong> Interconnect Designer (Global Electronics Association)</li>

--- a/src/components/footer.html
+++ b/src/components/footer.html
@@ -8,11 +8,6 @@
           Creating a <span class="logo-solid">S<span class="letter-o">O</span>LID</span> foundation for your next idea. 
           Expert hardware product design and engineering services for startups and established companies.
         </p>
-        <div>
-          <a href="mailto:hello@solidpd.com" class="social-link">
-            hello@solidpd.com
-          </a>
-        </div>
       </div>
       
       <!-- Quick Links -->
@@ -33,7 +28,9 @@
           <svg width="24" height="24" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/>
           </svg>
-          LinkedIn
+        </a>
+        <a href="mailto:hello@solidpd.com" class="social-link">
+          hello@solidpd.com
         </a>
       </div>
     </div>


### PR DESCRIPTION
- Moves the email address to the 'Connect' section in the footer.
- Removes the 'LinkedIn' text from the social link in the footer, leaving only the icon.
- Removes 'Senior' from Matt Starfield's title on the about page.