### PR TITLE
feat: Replace hero image with stylized page header

### DIFF
--- a/src/about.html
+++ b/src/about.html
@@ -16,18 +16,18 @@
     <!-- HEADER_PLACEHOLDER -->
 
     <!-- Header Section -->
-    <section class="hero">
-        <div class="hero-background">
-            <img src="./assets/images/hero-workshop-background.jpg" alt="Product Development Workshop" class="hero-bg-image">
-        </div>
-        <div class="hero-content">
-            <div class="hero-text">
-                <h1>About</h1>
-                <p class="hero-subtitle">Passionate • Curious • Relentless</p>
-                <p class="hero-description">We are a team of engineers, designers, and strategists who believe in the power of thoughtful product development. Our mission is to help innovative companies bring breakthrough products to market faster and more efficiently than ever before.</p>
+    <header class="page-header">
+        <div class="page-header-container">
+            <div class="page-header-text-wrapper">
+                <div class="page-header-text-box">
+                    <h1>About</h1>
+                    <p class="hero-subtitle">Passionate • Curious • Relentless</p>
+                    <p class="hero-description">We are a team of engineers, designers, and strategists who believe in the power of thoughtful product development. Our mission is to help innovative companies bring breakthrough products to market faster and more efficiently than ever before.</p>
+                </div>
             </div>
+            <div class="page-header-decorative-box"></div>
         </div>
-    </section>
+    </header>
 
     <!-- From The Workshop to the WORLD Section with Globe Background -->
     <section class="workshop-world-globe">

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -757,6 +757,111 @@ blockquote::after {
     }
 }
 
+/* New Page Header for subpages */
+.page-header {
+    position: relative;
+    padding-top: 140px; /* Space for navbar and some breathing room */
+    padding-bottom: 80px;
+    padding-left: 2rem;
+    padding-right: 2rem;
+    background-color: #fff;
+    overflow: hidden; /* To contain decorative elements that might poke out */
+}
+
+.page-header-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    position: relative;
+}
+
+.page-header-text-wrapper {
+    position: relative;
+    z-index: 2;
+    max-width: 65%;
+}
+
+.page-header-text-box {
+    background-color: rgba(240, 240, 240, 0.9); /* Semi-transparent grayish */
+    padding: 2.5rem;
+    border-radius: 8px;
+    position: relative;
+}
+
+.page-header-text-box h1 {
+    font-size: 3rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+    color: #333;
+}
+
+.page-header-text-box .hero-subtitle {
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    color: #333;
+}
+
+.page-header-text-box .hero-description {
+    font-size: 1.1rem;
+    line-height: 1.6;
+    color: #555;
+}
+
+.page-header-decorative-box {
+    position: absolute;
+    width: 45%;
+    height: 150px;
+    background-color: #f5f5f5; /* Lighter solid gray */
+    bottom: -40px;
+    right: 0;
+    z-index: 1;
+    border-radius: 8px;
+}
+
+@media (max-width: 992px) {
+    .page-header-text-wrapper {
+        max-width: 75%;
+    }
+    .page-header-decorative-box {
+        width: 50%;
+    }
+}
+
+@media (max-width: 768px) {
+    .page-header {
+        padding-top: 120px;
+        padding-bottom: 60px;
+    }
+    .page-header-text-wrapper {
+        max-width: 90%;
+    }
+    .page-header-text-box h1 {
+        font-size: 2.5rem;
+    }
+    .page-header-decorative-box {
+        width: 60%;
+        height: 120px;
+        bottom: -20px;
+        right: 0;
+    }
+}
+
+@media (max-width: 480px) {
+    .page-header-text-wrapper {
+        max-width: 100%;
+    }
+    .page-header-text-box {
+        padding: 2rem;
+    }
+    .page-header-text-box h1 {
+        font-size: 2rem;
+    }
+    .page-header-decorative-box {
+        display: none; /* Hide for simplicity on small screens */
+    }
+}
+
 /* About Page Specific Styles */
 .workshop-world {
     background: #000;

--- a/src/services.html
+++ b/src/services.html
@@ -16,17 +16,17 @@
     <!-- HEADER_PLACEHOLDER -->
 
     <!-- Header Section -->
-    <section class="hero">
-        <div class="hero-background">
-            <img src="./assets/images/hero-workshop-background.jpg" alt="Product Development Workshop" class="hero-bg-image">
-        </div>
-        <div class="hero-content">
-            <div class="hero-text">
-                <h1>Services</h1>
-                <p class="hero-description">We offer comprehensive product development services from initial concept through manufacturing and launch. Our integrated approach ensures seamless execution across all phases of your product journey.</p>
+    <header class="page-header">
+        <div class="page-header-container">
+            <div class="page-header-text-wrapper">
+                <div class="page-header-text-box">
+                    <h1>Services</h1>
+                    <p class="hero-description">We offer comprehensive product development services from initial concept through manufacturing and launch. Our integrated approach ensures seamless execution across all phases of your product journey.</p>
+                </div>
             </div>
+            <div class="page-header-decorative-box"></div>
         </div>
-    </section>
+    </header>
 
     <!-- Service Areas -->
     <section class="service-areas">

--- a/src/work.html
+++ b/src/work.html
@@ -16,18 +16,18 @@
     <!-- HEADER_PLACEHOLDER -->
 
     <!-- Header Section -->
-    <section class="hero">
-        <div class="hero-background">
-            <img src="./assets/images/hero-workshop-background.jpg" alt="Product Development Workshop" class="hero-bg-image">
-        </div>
-        <div class="hero-content">
-            <div class="hero-text">
-                <h1>Work</h1>
-                <p class="hero-subtitle">Intuitive • Impactful • Innovative</p>
-                <p class="hero-description">We partner with clients driven to solve problems and create products that make a real impact. Their vision inspires us to push the boundaries of what's possible. Creativity and innovation are at the heart of everything we do, resulting in products that truly resonate.</p>
+    <header class="page-header">
+        <div class="page-header-container">
+            <div class="page-header-text-wrapper">
+                <div class="page-header-text-box">
+                    <h1>Work</h1>
+                    <p class="hero-subtitle">Intuitive • Impactful • Innovative</p>
+                    <p class="hero-description">We partner with clients driven to solve problems and create products that make a real impact. Their vision inspires us to push the boundaries of what's possible. Creativity and innovation are at the heart of everything we do, resulting in products that truly resonate.</p>
+                </div>
             </div>
+            <div class="page-header-decorative-box"></div>
         </div>
-    </section>
+    </header>
 
     <!-- Portfolio Items -->
     <section class="portfolio-items">


### PR DESCRIPTION
Removes the full-height hero image from the 'about', 'services', and 'work' pages, while keeping it on the homepage.

Introduces a new `page-header` component to replace the hero section on these subpages. The new header features:
- A top-left aligned text box with a semi-transparent background.
- A decorative solid gray box positioned below and to the right of the text.
- A reduced height compared to the original hero section.
- Responsive design to ensure proper display on various screen sizes.

This change aligns with the request to create a more distinct and less intrusive header for the site's interior pages.