### PR TITLE
refactor: Darken header boxes and center footer icons

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -731,6 +731,10 @@ blockquote::after {
         grid-template-columns: 1fr;
         text-align: center;
     }
+
+    .social-links {
+        justify-content: center;
+    }
     
     .footer-bottom {
         flex-direction: column;
@@ -781,7 +785,7 @@ blockquote::after {
 }
 
 .page-header-text-box {
-    background-color: rgba(240, 240, 240, 0.9); /* Semi-transparent grayish */
+    background-color: rgba(224, 224, 224, 0.9); /* Semi-transparent grayish */
     padding: 2.5rem;
     border-radius: 8px;
     position: relative;
@@ -812,7 +816,7 @@ blockquote::after {
     position: absolute;
     width: 45%;
     height: 150px;
-    background-color: #f5f5f5; /* Lighter solid gray */
+    background-color: #e0e0e0; /* Lighter solid gray */
     bottom: -40px;
     right: 0;
     z-index: 1;


### PR DESCRIPTION
This commit addresses two styling requests:

1.  The header boxes on all sub-pages have been darkened for better visual contrast. The background colors for `.page-header-text-box` and `.page-header-decorative-box` were updated to darker shades of gray.

2.  The social media icons (LinkedIn and email) in the footer are now centered on mobile devices. This was achieved by adding `justify-content: center` to the `.social-links` class within the mobile media query, ensuring the change only affects smaller screens.