### PR TITLE
Fix: Corrects header logo display and size

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -39,7 +39,7 @@ body {
 }
 
 .logo {
-    height: 40px;
+    height: 60px; /* Increased logo size */
     width: auto;
     transition: height 0.3s ease;
 }
@@ -50,7 +50,7 @@ body {
 }
 
 .logo-horizontal {
-    display: none;
+    display: none; /* Hidden by default */
 }
 
 .nav-menu {
@@ -669,17 +669,17 @@ blockquote::after {
 }
 
 /* Responsive Design */
-.navbar.menu-active .logo-default {
-    display: none;
-}
-
-.navbar.menu-active .logo-horizontal {
-    display: block;
-}
-
 @media (max-width: 768px) {
+    .logo-default {
+        display: none;
+    }
+
+    .logo-horizontal {
+        display: block;
+    }
+
     .logo {
-        height: 50px; /* Increased logo size on mobile */
+        height: 40px; /* Adjusted for horizontal logo */
     }
 
     .hamburger {


### PR DESCRIPTION
This commit resolves an issue where the header logo was too small on desktop and did not display correctly across different screen sizes.

The following changes were made:
- Increased the height of the default (stacked) logo for better visibility on desktop.
- Implemented a CSS media query to switch to the horizontal logo on mobile screens (max-width: 768px).
- Removed obsolete CSS rules that tied logo visibility to the mobile menu's state.