### PR TITLE
feat: Update decorative text box style

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -824,7 +824,7 @@ blockquote::after {
 }
 
 .page-header-text-box {
-    background-color: rgba(224, 224, 224, 0.9); /* Semi-transparent grayish */
+    background-color: rgba(51, 51, 51, 0.9); /* Semi-transparent dark gray */
     padding: 2.5rem;
     border-radius: 8px;
     position: relative;
@@ -834,7 +834,7 @@ blockquote::after {
     font-size: 3rem;
     font-weight: 700;
     margin-bottom: 1rem;
-    color: #333;
+    color: #fff;
 }
 
 .page-header-text-box .hero-subtitle {
@@ -842,13 +842,13 @@ blockquote::after {
     font-weight: 700;
     margin-top: 1rem;
     margin-bottom: 1rem;
-    color: #333;
+    color: #fff;
 }
 
 .page-header-text-box .hero-description {
     font-size: 1.1rem;
     line-height: 1.6;
-    color: #555;
+    color: #f0f0f0;
 }
 
 .page-header-decorative-box {


### PR DESCRIPTION
Makes the decorative text box semi-transparent with a dark background.

The background color of the `.page-header-text-box` is changed to a semi-transparent #333333. The text color inside the box is changed to white to ensure readability against the new dark background. The overlapping decorative box is not affected.