### PR TITLE
Fix: Ensure hamburger menu expands correctly on mobile

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -670,6 +670,11 @@ blockquote::after {
 
 /* Responsive Design */
 @media (max-width: 768px) {
+    .navbar-mobile.menu-active {
+        height: 100vh;
+        align-items: flex-start;
+    }
+
     .logo-default {
         display: none;
     }

--- a/src/components/header.html
+++ b/src/components/header.html
@@ -1,4 +1,4 @@
-<nav class="navbar">
+<nav class="navbar navbar-mobile">
   <div class="container nav-container">
     <a href="/index.html" class="nav-brand">
       <img src="/assets/images/Solid-Product-Design-logo-stacked-black.png" alt="Solid Product Design" class="logo logo-default">


### PR DESCRIPTION
The hamburger menu was not expanding to the full height of the viewport on mobile devices when activated. This was due to missing CSS rules to handle the active state of the mobile navigation bar.

This commit introduces a `navbar-mobile` class to the header and adds corresponding CSS to make the menu expand to 100vh when the `menu-active` class is present. This ensures a consistent and user-friendly experience on mobile devices.