### PR TITLE
fix: add type=module to script tags

### DIFF
--- a/src/about.html
+++ b/src/about.html
@@ -161,6 +161,6 @@
 
     <!-- Footer -->
     <!-- FOOTER_PLACEHOLDER -->
-    <script src="./assets/js/main.js"></script>
+    <script type="module" src="./assets/js/main.js"></script>
 </body>
 </html>

--- a/src/contact.html
+++ b/src/contact.html
@@ -29,6 +29,6 @@
 
     <!-- Footer -->
     <!-- FOOTER_PLACEHOLDER -->
-    <script src="./assets/js/main.js"></script>
+    <script type="module" src="./assets/js/main.js"></script>
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -148,6 +148,6 @@
     </section>
 
     <!-- FOOTER_PLACEHOLDER -->
-    <script src="./assets/js/main.js"></script>
+    <script type="module" src="./assets/js/main.js"></script>
 </body>
 </html>

--- a/src/services.html
+++ b/src/services.html
@@ -158,6 +158,6 @@
 
     <!-- Footer -->
     <!-- FOOTER_PLACEHOLDER -->
-    <script src="./assets/js/main.js"></script>
+    <script type="module" src="./assets/js/main.js"></script>
 </body>
 </html>

--- a/src/work.html
+++ b/src/work.html
@@ -149,6 +149,6 @@
 
     <!-- Footer -->
     <!-- FOOTER_PLACEHOLDER -->
-    <script src="./assets/js/main.js"></script>
+    <script type="module" src="./assets/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The javascript was not being bundled correctly during the build process because the script tags in the HTML files were missing the `type="module"` attribute. This caused the javascript to not load on the built pages, breaking functionality like the hamburger menu.

This change adds the `type="module"` attribute to the script tags in all HTML files, which allows Vite to correctly bundle the javascript and fixes the issue.