### PR TITLE
refactor: Improve heading layout and fix logo spacing

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -172,6 +172,7 @@ body {
 
 .solid-word-image {
     height: 7rem; /* Increased size by 2x */
+    margin: 1rem 0;
 }
 
 .content-wrapper {
@@ -183,12 +184,16 @@ body {
 .main-heading {
     font-size: 4rem;
     font-weight: 400;
-    line-height: 1.4; /* Adjusted for larger image */
     color: #333;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
+}
+
+.heading-line {
+    display: block;
+    line-height: 1.2;
 }
 
 .solid-text {

--- a/src/index.html
+++ b/src/index.html
@@ -30,9 +30,11 @@
     <!-- Main Content -->
     <section class="main-content">
         <div class="content-wrapper">
-            <h2 class="main-heading">Creating a<br>
-            <img src="./assets/images/Solid-w-yellow-for-index.png" alt="Solid" class="solid-word-image"><br>
-            foundation for your next idea.</h2>
+            <h2 class="main-heading">
+                <span class="heading-line">Creating a</span>
+                <img src="./assets/images/Solid-w-yellow-for-index.png" alt="Solid" class="solid-word-image">
+                <span class="heading-line">foundation for your next idea.</span>
+            </h2>
         </div>
     </section>
 


### PR DESCRIPTION
This commit refactors the HTML structure of the main heading to provide better control over layout and spacing, resolving an issue with excessive space around the logo.

The following changes were made:

- Replaced `<br>` tags with `<span>` elements for each line of text in the main heading in `src/index.html`. This allows for more precise CSS styling.
- Updated `src/assets/css/main.css` to support the new structure:
  - Removed the `line-height` from the `.main-heading` class.
  - Added a new `.heading-line` class with `display: block` and a controlled `line-height` to manage the text flow.
  - Adjusted the vertical `margin` on the `.solid-word-image` class to ensure balanced spacing between the text and the logo.