### PR TITLE
Fix nav bar gap in Safari landscape mode by using safe area insets.

### DIFF
--- a/src/about.html
+++ b/src/about.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>About - Solid Product Design</title>
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -26,6 +26,7 @@ body {
     backdrop-filter: blur(10px);
     z-index: 1000;
     padding: 1rem 0;
+    padding-top: calc(1rem + env(safe-area-inset-top));
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 }
 
@@ -574,6 +575,7 @@ blockquote::after {
     background: #333;
     color: white;
     padding: 4rem 0 2rem;
+    padding-bottom: calc(2rem + env(safe-area-inset-bottom));
 }
 
 .footer-container {

--- a/src/contact.html
+++ b/src/contact.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Contact - Solid Product Design</title>
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Solid Product Design - Creating a SOLID foundation for your next idea</title>
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">

--- a/src/services.html
+++ b/src/services.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Services - Solid Product Design</title>
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">

--- a/src/work.html
+++ b/src/work.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Work - Solid Product Design</title>
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">

--- a/vite-html-inject.js
+++ b/vite-html-inject.js
@@ -2,14 +2,18 @@ import fs from 'fs';
 import path from 'path';
 
 export default function htmlInject() {
+  let config;
+
   return {
     name: 'html-inject',
+    configResolved(resolvedConfig) {
+      config = resolvedConfig;
+    },
     transformIndexHtml: {
       order: 'pre',
       handler(html, ctx) {
-        // Read header and footer components
-        const headerPath = path.resolve('src/components/header.html');
-        const footerPath = path.resolve('src/components/footer.html');
+        const headerPath = path.resolve(config.root, 'components/header.html');
+        const footerPath = path.resolve(config.root, 'components/footer.html');
         
         let headerHtml = '';
         let footerHtml = '';
@@ -26,7 +30,6 @@ export default function htmlInject() {
           console.warn('Footer component not found:', footerPath);
         }
         
-        // Replace placeholders with actual components
         html = html.replace('<!-- HEADER_PLACEHOLDER -->', headerHtml);
         html = html.replace('<!-- FOOTER_PLACEHOLDER -->', footerHtml);
         


### PR DESCRIPTION
On mobile Safari in landscape mode, a gap would appear between the top of the screen and the navigation bar when the address bar was hidden.

This was resolved by:
- Adding `viewport-fit=cover` to the viewport meta tag in all HTML files.
- Using `env(safe-area-inset-top)` and `env(safe-area-inset-bottom)` to add padding to the header and footer, ensuring they are positioned correctly within the safe area of the screen.

Additionally, this change includes a fix for a bug in the `vite-html-inject.js` plugin that was preventing the Vite development server from starting correctly. The plugin was updated to resolve component paths relative to Vite's configured root directory.