### PR TITLE
Refactor: Remove unused CSS styles from main.css

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -288,43 +288,6 @@ body {
     font-weight: 500;
 }
 
-/* Quote Section */
-.quote-section {
-    background: white;
-    padding: 6rem 0;
-}
-
-.quote-container {
-    max-width: 1000px;
-    margin: 0 auto;
-    padding: 0 2rem;
-    text-align: center;
-}
-
-blockquote {
-    font-size: 1.5rem;
-    line-height: 1.6;
-    color: #333;
-    margin-bottom: 4rem;
-    font-style: italic;
-}
-
-blockquote::before,
-blockquote::after {
-    content: '"';
-    font-size: 2rem;
-    color: #4A90E2;
-}
-
-.clients-intro {
-    font-size: 1.1rem;
-    color: #666;
-    margin-bottom: 3rem;
-    max-width: 600px;
-    margin-left: auto;
-    margin-right: auto;
-    line-height: 1.6;
-}
 
 .client-logos {
     display: grid;
@@ -918,19 +881,6 @@ blockquote::after {
 }
 
 /* About Page Specific Styles */
-.workshop-world {
-    background: #000;
-    color: white;
-    padding: 6rem 0;
-    text-align: center;
-}
-
-.workshop-world h2 {
-    font-size: 3.5rem;
-    font-weight: 700;
-    margin: 0;
-    line-height: 1.2;
-}
 
 /* Workshop World Globe Section */
 .workshop-world-globe {
@@ -1013,24 +963,6 @@ blockquote::after {
     height: auto;
     border-radius: 8px;
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
-}
-
-.company-story {
-    background: white;
-    padding: 6rem 0;
-}
-
-.story-container {
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 0 2rem;
-    text-align: center;
-}
-
-.story-container p {
-    font-size: 1.2rem;
-    line-height: 1.8;
-    color: #555;
 }
 
 .small-team {
@@ -1570,112 +1502,6 @@ blockquote::after {
     }
 }
 
-/* World Section */
-.world-section {
-    background: #333;
-    color: white;
-    padding: 4rem 0;
-}
-
-.world-container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 2rem;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 4rem;
-    align-items: center;
-}
-
-.world-image {
-    position: relative;
-    border-radius: 8px;
-    overflow: hidden;
-}
-
-.world-image img {
-    width: 100%;
-    height: 400px;
-    object-fit: cover;
-}
-
-.world-overlay {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    text-align: center;
-    color: white;
-}
-
-.world-overlay h2 {
-    font-size: 2.5rem;
-    font-weight: 300;
-    line-height: 1.2;
-}
-
-.workshop-text {
-    font-style: italic;
-    font-weight: 400;
-}
-
-.world-text {
-    font-weight: 700;
-    font-size: 3rem;
-}
-
-.world-content p {
-    font-size: 1.1rem;
-    line-height: 1.6;
-    margin-bottom: 2rem;
-}
-
-.world-images {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1rem;
-}
-
-.world-img {
-    width: 100%;
-    height: 150px;
-    object-fit: cover;
-    border-radius: 8px;
-}
-
-/* Team Value Section */
-.team-value {
-    background: #f8f9fa;
-    padding: 4rem 0;
-}
-
-.team-value-container {
-    max-width: 1000px;
-    margin: 0 auto;
-    padding: 0 2rem;
-    text-align: center;
-}
-
-.team-value h2 {
-    font-size: 2.5rem;
-    margin-bottom: 2rem;
-    color: #333;
-}
-
-.small-text {
-    color: #4A90E2;
-}
-
-.big-text {
-    color: #4A90E2;
-    font-weight: 700;
-}
-
-.team-value p {
-    font-size: 1.1rem;
-    line-height: 1.6;
-    color: #666;
-}
 
 /* Team Section */
 .team-section {


### PR DESCRIPTION
This commit removes several unused CSS selectors from `src/assets/css/main.css`.

The following selectors and their corresponding styles have been removed after verifying they are not in use in any of the project's HTML files:
- `.quote-section`
- `.clients-intro`
- `.workshop-world`
- `.company-story`
- `.world-section`
- `.team-value`

This change reduces the size of the stylesheet, improving performance and maintainability.