### PR TITLE
feat: Dynamically update footer copyright year

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -21,4 +21,10 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
     }
+
+    // Update footer year
+    const yearSpan = document.getElementById('current-year');
+    if (yearSpan) {
+        yearSpan.textContent = new Date().getFullYear();
+    }
 });

--- a/src/components/footer.html
+++ b/src/components/footer.html
@@ -42,7 +42,7 @@
     <!-- Bottom Bar -->
     <div class="footer-bottom">
       <div class="footer-legal">
-        <p>© 2024 Solid Product Design. All rights reserved.</p>
+        <p>© <span id="current-year"></span> Solid Product Design. All rights reserved.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This commit modifies the footer to ensure the copyright year is always current.

- Replaces the hardcoded year in `src/components/footer.html` with a `<span>` element with the ID `current-year`.
- Adds JavaScript to `src/assets/js/main.js` to set the text content of the `current-year` span to the current year on page load.