### PR TITLE
fix: Correct Netlify Forms POST URL to use current page path

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -854,7 +854,7 @@
       try {
         const formData = new FormData(contactForm);
 
-        const response = await fetch('/', {
+        const response = await fetch(window.location.pathname, {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           body: new URLSearchParams(formData).toString()

--- a/labs.html
+++ b/labs.html
@@ -1577,7 +1577,7 @@
       try {
         const formData = new FormData(labsForm);
 
-        const response = await fetch('/', {
+        const response = await fetch(window.location.pathname, {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           body: new URLSearchParams(formData).toString()


### PR DESCRIPTION
## Summary

Fixes form submission 404 error by correcting the POST URL.

### Problem
Forms were POSTing to `/` (root) which returned 404. Netlify Forms expects the POST to go to the same URL as the page containing the form.

### Solution
Changed `fetch('/')` to `fetch(window.location.pathname)` in both:
- `contact.html` - POSTs to `/contact.html`
- `labs.html` - POSTs to `/labs.html`

## Test Plan
- [ ] Submit test message on contact.html
- [ ] Submit test message on labs.html
- [ ] Verify submissions appear in Netlify Forms dashboard

Relates to #64

🤖 Generated with [Claude Code](https://claude.ai/code)

via [HAPI](https://hapi.run)

Co-Authored-By: HAPI <noreply@hapi.run>