### PR TITLE
Replace labs header logo with Solid Labs wordmark

### DIFF
--- a/labs.html
+++ b/labs.html
@@ -1191,9 +1191,9 @@
   <header class="nav-header">
     <nav class="nav-container" aria-label="Main navigation">
       <a href="/" class="nav-logo" aria-label="Solid Labs Home">
-        <img src="images/assets/Solid-O3-horizontal-black.png"
-             alt="Solid Product Design"
-             width="83" height="50" />
+        <img src="images/assets/Solid-Labs-logo-horizontal-black.png"
+             alt="Solid Labs"
+             width="232" height="68" />
       </a>
 
       <button class="nav-toggle" aria-label="Toggle navigation menu" aria-expanded="false">


### PR DESCRIPTION
## Summary
- Replaces the triple-O mark (`Solid-O3-horizontal-black.png`) with the full Solid Labs horizontal wordmark (`Solid-Labs-logo-horizontal-black.png`) in the labs page header
- The stylized "O" renders at the same size as the original circles (both source images share the same 1000px native height)
- Updated alt text from "Solid Product Design" to "Solid Labs"

Closes #153

## Test plan
- [x] Desktop (1280px) - logo displays correctly alongside nav items
- [x] Mobile (375px) - logo scales properly, no horizontal overflow
- [x] Staging preview verified: https://698545f413b9f3478221d9b4--solidpd.netlify.app/labs.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)

via [HAPI](https://hapi.run)